### PR TITLE
Fix CSS theme

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,7 +1,7 @@
 body {
-  background: #fafafa;
-  color: #222;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #1a1a1a;
+  color: #ffffff;
+  font-family: "Consolas", "Courier New", monospace;
   line-height: 1.6;
   margin: 0;
   padding: 0;
@@ -59,6 +59,11 @@ th, td {
 th {
   background-color: #f0f0f0;
   font-weight: bold;
+}
+
+b,
+strong {
+  color: #cccccc;
 }
 
 tr:nth-child(even) {


### PR DESCRIPTION
## Summary
- tweak stylesheet to use 90% gray background and white text
- use console-style font
- display bold text in lighter gray

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_687a769b805c832f845db220a0f67afb